### PR TITLE
Allow returning to be specified for PostgreSQL

### DIFF
--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -61,6 +61,19 @@ def should_support_postgresql_import_functionality
         assert_equal [], Book.import(books, no_returning: true).ids
       end
     end
+
+    describe "returning" do
+      let(:books) { [Book.new(author_name: "King", title: "It")] }
+      let(:result) { Book.import(books, returning: %w(author_name title)) }
+
+      it "creates records" do
+        assert_difference("Book.count", +1) { result }
+      end
+
+      it "returns specified columns" do
+        assert_equal [%w(King It)], result.ids
+      end
+    end
   end
 
   if ENV['AR_VERSION'].to_f >= 4.0


### PR DESCRIPTION
This change allows us to return arbitrary columns, not just the primary key, from imports. 

The code will be contributed back to the original repo, but for now this allows fork allows us to use it in dandelion.

Prime: @jturkel 