### PR TITLE
Allow returning for PostgreSQL with ids and results returned separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,15 @@ addons:
       - postgresql-9.5-postgis-2.3
 
 script:
-#  - bundle exec rake test:mysql2
-#  - bundle exec rake test:mysql2_makara
-#  - bundle exec rake test:mysql2spatial
+  - bundle exec rake test:mysql2
+  - bundle exec rake test:mysql2_makara
+  - bundle exec rake test:mysql2spatial
   - bundle exec rake test:postgis
   - bundle exec rake test:postgresql
   - bundle exec rake test:postgresql_makara
-#  - bundle exec rake test:seamless_database_pool
-#  - bundle exec rake test:spatialite
-#  - bundle exec rake test:sqlite3
+  - bundle exec rake test:seamless_database_pool
+  - bundle exec rake test:spatialite
+  - bundle exec rake test:sqlite3
   - bundle exec rubocop
 
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,15 @@ addons:
       - postgresql-9.5-postgis-2.3
 
 script:
-  - bundle exec rake test:mysql2
-  - bundle exec rake test:mysql2_makara
-  - bundle exec rake test:mysql2spatial
+#  - bundle exec rake test:mysql2
+#  - bundle exec rake test:mysql2_makara
+#  - bundle exec rake test:mysql2spatial
   - bundle exec rake test:postgis
   - bundle exec rake test:postgresql
   - bundle exec rake test:postgresql_makara
-  - bundle exec rake test:seamless_database_pool
-  - bundle exec rake test:spatialite
-  - bundle exec rake test:sqlite3
+#  - bundle exec rake test:seamless_database_pool
+#  - bundle exec rake test:spatialite
+#  - bundle exec rake test:sqlite3
   - bundle exec rubocop
 
 dist: trusty

--- a/lib/activerecord-import/adapters/abstract_adapter.rb
+++ b/lib/activerecord-import/adapters/abstract_adapter.rb
@@ -16,7 +16,7 @@ module ActiveRecord::Import::AbstractAdapter
       sql2insert = base_sql + values.join( ',' ) + post_sql
       insert( sql2insert, *args )
 
-      [number_of_inserts, []]
+      ActiveRecord::Import::Result.new([], number_of_inserts, [], [])
     end
 
     def pre_sql_statements(options)

--- a/lib/activerecord-import/adapters/mysql_adapter.rb
+++ b/lib/activerecord-import/adapters/mysql_adapter.rb
@@ -49,7 +49,7 @@ module ActiveRecord::Import::MysqlAdapter
       end
     end
 
-    [number_of_inserts, []]
+    ActiveRecord::Import::Result.new([], number_of_inserts, [], [])
   end
 
   # Returns the maximum number of bytes that the server will allow

--- a/lib/activerecord-import/adapters/sqlite3_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlite3_adapter.rb
@@ -37,7 +37,7 @@ module ActiveRecord::Import::SQLite3Adapter
       end
     end
 
-    [number_of_inserts, []]
+    ActiveRecord::Import::Result.new([], number_of_inserts, [], [])
   end
 
   def pre_sql_statements( options)

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -61,6 +61,19 @@ def should_support_postgresql_import_functionality
         assert_equal [], Book.import(books, no_returning: true).ids
       end
     end
+
+    describe "returning" do
+      let(:books) { [Book.new(author_name: "King", title: "It")] }
+      let(:result) { Book.import(books, returning: %w(author_name title)) }
+
+      it "creates records" do
+        assert_difference("Book.count", +1) { result }
+      end
+
+      it "returns specified columns" do
+        assert_equal [%w(King It)], result.ids
+      end
+    end
   end
 
   if ENV['AR_VERSION'].to_f >= 4.0

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -65,13 +65,33 @@ def should_support_postgresql_import_functionality
     describe "returning" do
       let(:books) { [Book.new(author_name: "King", title: "It")] }
       let(:result) { Book.import(books, returning: %w(author_name title)) }
+      let(:book_id) { books.first.id.to_s }
 
       it "creates records" do
         assert_difference("Book.count", +1) { result }
       end
 
+      it "returns ids" do
+        result
+        assert_equal [book_id], result.ids
+      end
+
       it "returns specified columns" do
-        assert_equal [%w(King It)], result.ids
+        assert_equal [%w(King It)], result.results
+      end
+
+      context "when primary key and returning overlap" do
+        let(:result) { Book.import(books, returning: %w(id title)) }
+
+        setup { result }
+
+        it "returns ids" do
+          assert_equal [book_id], result.ids
+        end
+
+        it "returns specified columns" do
+          assert_equal [[book_id, 'It']], result.results
+        end
       end
     end
   end

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -65,7 +65,13 @@ def should_support_postgresql_import_functionality
     describe "returning" do
       let(:books) { [Book.new(author_name: "King", title: "It")] }
       let(:result) { Book.import(books, returning: %w(author_name title)) }
-      let(:book_id) { ENV['AR_VERSION'].to_i >= 5.0 ? books.first.id : books.first.id.to_s }
+      let(:book_id) do
+        if RUBY_PLATFORM == 'java' || ENV['AR_VERSION'].to_i >= 5.0
+          books.first.id
+        else
+          books.first.id.to_s
+        end
+      end
 
       it "creates records" do
         assert_difference("Book.count", +1) { result }

--- a/test/support/postgresql/import_examples.rb
+++ b/test/support/postgresql/import_examples.rb
@@ -65,7 +65,7 @@ def should_support_postgresql_import_functionality
     describe "returning" do
       let(:books) { [Book.new(author_name: "King", title: "It")] }
       let(:result) { Book.import(books, returning: %w(author_name title)) }
-      let(:book_id) { books.first.id.to_s }
+      let(:book_id) { ENV['AR_VERSION'].to_i >= 5.0 ? books.first.id : books.first.id.to_s }
 
       it "creates records" do
         assert_difference("Book.count", +1) { result }


### PR DESCRIPTION
This change allows us to return arbitrary columns, not just the primary key, from imports. 

The code will be contributed back to the original repo, but for now this allows fork allows us to use it in dandelion.

I took the approach of always including primary keys if defined on the table, since the gem uses them internally to update models.

Prime: @jturkel 